### PR TITLE
Feature/3 Elasticssearch로 사용자 질의 캐시 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation 'org.springframework.ai:spring-ai-tika-document-reader'
     implementation 'org.aspectj:aspectjrt'
     implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'group.springframework.ai:spring-ai-redis-store-spring-boot-starter:1.1.0'
 
 
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -30,11 +30,15 @@ dependencies {
     implementation 'org.springframework.ai:spring-ai-tika-document-reader'
     implementation 'org.aspectj:aspectjrt'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'group.springframework.ai:spring-ai-redis-store-spring-boot-starter:1.1.0'
+
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.1
+    container_name: elasticsearch-container
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    networks:
+      - elastic
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.14.1
+    container_name: kibana-container
+    environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    networks:
+      - elastic
+    depends_on:
+      - elasticsearch
+
+volumes:
+  es_data:
+
+networks:
+  elastic:
+    driver: bridge
+

--- a/src/main/java/com/kobot/backend/CacheDto.java
+++ b/src/main/java/com/kobot/backend/CacheDto.java
@@ -1,0 +1,16 @@
+package com.kobot.backend;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CacheDto {
+
+    private String id;
+    private String query;
+    private String answer;
+    private float distance;
+}

--- a/src/main/java/com/kobot/backend/CacheDto.java
+++ b/src/main/java/com/kobot/backend/CacheDto.java
@@ -3,10 +3,12 @@ package com.kobot.backend;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @AllArgsConstructor
 @Builder
+@ToString
 public class CacheDto {
 
     private String id;

--- a/src/main/java/com/kobot/backend/service/EsCacheService.java
+++ b/src/main/java/com/kobot/backend/service/EsCacheService.java
@@ -1,0 +1,100 @@
+package com.kobot.backend.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.IndexRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.kobot.backend.CacheDto;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.model.EmbeddingUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EsCacheService {
+
+    private final EmbeddingModel embeddingModel;
+    private final ElasticsearchClient client;
+    private final String indexName = "kobot-user-query-index";
+    private final float threshold = 0.8f;
+    private final long topK = 1L;
+
+    public CacheDto cache(String query, String answer) {
+        // metadata set
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("answer", answer);
+        metadata.put("timestamp", System.currentTimeMillis());
+
+        // document set
+        Document document = new Document(query, metadata);
+
+        // embedding
+        document.setEmbedding(embeddingModel.embed(document));
+
+        IndexRequest<Document> indexRequest = new IndexRequest.Builder<Document>()
+            .index(indexName)
+            .id(UUID.randomUUID().toString())
+            .document(document)
+            .build();
+
+        // insert
+        try {
+            client.index(indexRequest);
+        } catch (ElasticsearchException | IOException e) {
+            log.error("", e);
+            return null;
+        }
+
+        return convertToCachedDto(document);
+    }
+
+    public CacheDto getCached(String query) {
+        float[] vectors = embeddingModel.embed(query);
+
+        SearchResponse<Document> res;
+        try {
+            res = client.search(
+                sr -> sr.index(indexName)
+                    .knn(knn -> knn.queryVector(EmbeddingUtils.toList(vectors))
+                        .similarity(threshold)
+                        .k(topK)
+                        .field("embedding")
+                        .numCandidates((long) (1.5 * topK))
+                    ),
+                Document.class);
+        } catch (IOException e) {
+            log.error("", e);
+            return null;
+        }
+
+        log.debug("Score: {}", res.maxScore());
+
+        return res.hits().hits().stream().map(r -> {
+            Document source = r.source();
+            source.getMetadata().put("distance", r.score().floatValue());
+            return convertToCachedDto(source);
+        }).collect(Collectors.toList()).getFirst();
+
+    }
+
+    private CacheDto convertToCachedDto(Document doc) {
+        Map<String, Object> metadata = doc.getMetadata();
+        Object distance = metadata.get("distance");
+
+        return CacheDto.builder()
+            .id(doc.getId())
+            .query((String) metadata.get("query"))
+            .answer((String) metadata.get("answer"))
+            .distance(distance == null ? -1f : (float) distance)
+            .build();
+    }
+}

--- a/src/main/java/com/kobot/backend/service/EsCacheService.java
+++ b/src/main/java/com/kobot/backend/service/EsCacheService.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
@@ -80,9 +79,14 @@ public class EsCacheService {
 
         return res.hits().hits().stream().map(r -> {
             Document source = r.source();
+            if (source == null) {
+                log.debug("'source' field is null from {}", r);
+                return null;
+            }
+
             source.getMetadata().put("distance", r.score().floatValue());
             return convertToCachedDto(source);
-        }).collect(Collectors.toList()).getFirst();
+        }).toList().getFirst();
 
     }
 

--- a/src/main/java/com/kobot/backend/service/EsCacheService.java
+++ b/src/main/java/com/kobot/backend/service/EsCacheService.java
@@ -28,6 +28,13 @@ public class EsCacheService {
     private final float threshold = 0.8f;
     private final long topK = 1L;
 
+    /**
+     * 질의와 답변을 캐시합니다.
+     *
+     * @param query  질의
+     * @param answer 답변
+     * @return 캐시된 객체. 캐시 실패 시, null
+     */
     public CacheDto cache(String query, String answer) {
         // metadata set
         Map<String, Object> metadata = new HashMap<>();
@@ -57,6 +64,12 @@ public class EsCacheService {
         return convertToCachedDto(document);
     }
 
+    /**
+     * 질의와 유사한 질답을 캐시에서 꺼냅니다.
+     *
+     * @param query 질의
+     * @return 질답. cache miss 시, null
+     */
     public CacheDto getCached(String query) {
         float[] vectors = embeddingModel.embed(query);
 

--- a/src/main/java/com/kobot/backend/service/EsCacheService.java
+++ b/src/main/java/com/kobot/backend/service/EsCacheService.java
@@ -7,6 +7,7 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import com.kobot.backend.CacheDto;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -77,7 +78,7 @@ public class EsCacheService {
 
         log.debug("Score: {}", res.maxScore());
 
-        return res.hits().hits().stream().map(r -> {
+        List<CacheDto> cacheDtos = res.hits().hits().stream().map(r -> {
             Document source = r.source();
             if (source == null) {
                 log.debug("'source' field is null from {}", r);
@@ -86,8 +87,12 @@ public class EsCacheService {
 
             source.getMetadata().put("distance", r.score().floatValue());
             return convertToCachedDto(source);
-        }).toList().getFirst();
+        }).toList();
+        if (cacheDtos.isEmpty()) {
+            return null;
+        }
 
+        return cacheDtos.getFirst();
     }
 
     private CacheDto convertToCachedDto(Document doc) {

--- a/src/test/java/com/kobot/backend/service/EsCacheServiceTest.java
+++ b/src/test/java/com/kobot/backend/service/EsCacheServiceTest.java
@@ -2,6 +2,7 @@ package com.kobot.backend.service;
 
 import com.kobot.backend.CacheDto;
 import com.kobot.backend.KobotBackendApplication;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
 @ContextConfiguration(classes = KobotBackendApplication.class)
+@Slf4j
 public class EsCacheServiceTest {
 
     @Autowired
@@ -25,6 +27,7 @@ public class EsCacheServiceTest {
     void testGetCached() {
         CacheDto cached = cacheService.getCached("한국의 수도는?");
         Assertions.assertThat(cached).isNotNull();
+        log.info("{}", cached);
 
     }
 }

--- a/src/test/java/com/kobot/backend/service/EsCacheServiceTest.java
+++ b/src/test/java/com/kobot/backend/service/EsCacheServiceTest.java
@@ -1,0 +1,30 @@
+package com.kobot.backend.service;
+
+import com.kobot.backend.CacheDto;
+import com.kobot.backend.KobotBackendApplication;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = KobotBackendApplication.class)
+public class EsCacheServiceTest {
+
+    @Autowired
+    EsCacheService cacheService;
+
+    @Test
+    void testCache() {
+        CacheDto result = cacheService.cache("한국의 수도가 어디야?", "서울");
+        Assertions.assertThat(result).isNotNull();
+    }
+
+    @Test
+    void testGetCached() {
+        CacheDto cached = cacheService.getCached("한국의 수도는?");
+        Assertions.assertThat(cached).isNotNull();
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3 

## 📝작업 내용
> Elasticsearch 기반의 사용자 질의/답변 캐시 기능 추가
- 별도의 index 설정해서 관리
  - spring ai에서 RAG 설정 시 참조하는 인덱스와 겹치지 않게 함
- 사용자 질의 임베딩해서 저장
  - DI 받은 embedding 모델을 사용하여 질의 임베딩
  - 캐싱 시, 임베딩된 질의 및 답변을 함께 저장
- cache hit: 벡터 유사도 검색 기반
  - 벡터 유사도는 cosine으로 계산
  - kNN 알고리즘을 사용하여 유사 벡터 검색
  - 설정한 임계값 이상의 벡터만 검색하는 조건 추가