### PR TITLE
redis vectorStore설정 후 임베딩 구현 #11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation 'org.springframework.ai:spring-ai-tika-document-reader'
     implementation 'org.aspectj:aspectjrt'
-    implementation 'org.springframework.kafka:spring-kafka'
-
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.ai:spring-ai-redis-store-spring-boot-starter'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/docker/docker-redis.sh
+++ b/docker/docker-redis.sh
@@ -1,0 +1,1 @@
+docker run -d --name redis-container -p 6379:6379 redis/redis-stack-server:latest

--- a/src/main/java/com/kobot/backend/config/RedisConfig.java
+++ b/src/main/java/com/kobot/backend/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.kobot.backend.config;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.RedisVectorStore;
+import org.springframework.ai.vectorstore.RedisVectorStore.MetadataField;
+import org.springframework.ai.vectorstore.RedisVectorStore.RedisVectorStoreConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import redis.clients.jedis.JedisPooled;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    public RedisVectorStore redisVectorStore(EmbeddingModel embeddingModel) {
+        RedisVectorStoreConfig config = RedisVectorStoreConfig.builder()
+            .withPrefix("doc:")
+            .withIndexName("spring-ai-index")
+            .withMetadataFields(
+                MetadataField.tag("answer"),
+                MetadataField.numeric("timestamp"))
+            .build();
+
+        JedisPooled jedis = new JedisPooled("localhost", 6379);
+
+        return new RedisVectorStore(config, embeddingModel, jedis,
+            true);
+    }
+}
+

--- a/src/main/java/com/kobot/backend/service/RedisCacheService.java
+++ b/src/main/java/com/kobot/backend/service/RedisCacheService.java
@@ -1,0 +1,83 @@
+package com.kobot.backend.service;
+
+import com.kobot.backend.CacheDto;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.RedisVectorStore;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisCacheService {
+
+    private final EmbeddingModel embeddingModel;
+    private final float threshold = 0.8f;
+    private final int topK = 1;
+    private final RedisVectorStore vectorStore;
+
+    /**
+     * 질의와 답변을 캐시합니다.
+     *
+     * @param query  질의
+     * @param answer 답변
+     * @return 캐시된 객체. 캐시 실패 시, null
+     */
+    public CacheDto cache(String query, String answer) {
+        // metadata set
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("answer", answer);
+        metadata.put("timestamp", System.currentTimeMillis());
+
+        // document set
+        Document document = new Document(query, metadata);
+
+        // embedding
+        document.setEmbedding(embeddingModel.embed(document));
+
+        List <Document> documents = List.of(document);
+        vectorStore.add(documents);
+
+        return convertToCachedDto(document);
+    }
+
+    /**
+     * 질의와 유사한 질답을 캐시에서 꺼냅니다.
+     *
+     * @param query 질의
+     * @return 질답. cache miss 시, null
+     */
+    public CacheDto getCached(String query) {
+        List<Document> documents = vectorStore.similaritySearch(
+            SearchRequest
+                .query(query)
+                .withTopK(topK)
+                .withSimilarityThreshold(threshold)
+        );
+
+        if (documents.isEmpty()){
+            return null;
+        }
+
+        return convertToCachedDto(documents.getFirst());
+    }
+
+    private CacheDto convertToCachedDto(Document doc) {
+        Map<String, Object> metadata = doc.getMetadata();
+        Object distance = metadata.get("distance");
+
+        return CacheDto.builder()
+            .id(doc.getId())
+            .query((String) metadata.get("query"))
+            .answer((String) metadata.get("answer"))
+            .distance(distance == null ? -1f : (float) distance)
+            .build();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,5 +7,10 @@ spring:
     uris: http://localhost:9200
     username: elastic
     password: changeme
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   profiles:
     include: secret

--- a/src/test/java/com/kobot/backend/service/RedisCacheServiceTest.java
+++ b/src/test/java/com/kobot/backend/service/RedisCacheServiceTest.java
@@ -1,0 +1,34 @@
+package com.kobot.backend.service;
+
+import com.kobot.backend.CacheDto;
+import com.kobot.backend.KobotBackendApplication;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@Slf4j
+@SpringBootTest
+@ContextConfiguration(classes = KobotBackendApplication.class)
+class RedisCacheServiceTest {
+
+    @Autowired
+    RedisCacheService redisCacheService;
+
+    @Test
+    void testCache() {
+        CacheDto result = redisCacheService.cache("한국의 수도가 어디야?", "서울");
+        Assertions.assertThat(result).isNotNull();
+    }
+
+    @Test
+    void testGetCached() {
+        CacheDto cached = redisCacheService.getCached("한국의 수도는?");
+        Assertions.assertThat(cached).isNotNull();
+        log.info("{}", cached);
+
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 

## 📝작업 내용
> Redis 기반의 사용자 질의/답변 캐시 기능 추가
- 별도의 RedisVectorStore를 설정
  - 현재 기본으로 사용하고 있는 VectorStore와 겹치지 않게  함
- 사용자 질의 임베딩해서 저장
  - 캐싱 시, 임베딩된 질의 및 답변을 함께 저장