### PR TITLE
Feature/6 Web Crawling 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.jsoup:jsoup:1.15.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kobot/backend/controller/CrawlingController.java
+++ b/src/main/java/com/kobot/backend/controller/CrawlingController.java
@@ -18,7 +18,7 @@ public class CrawlingController {
     @GetMapping("/crawl")
     public String crawl(@RequestParam String url) {
         try {
-            crawlingService.crawl(url);
+            crawlingService.startCrawling(url);
             return "Crawling completed!";
         } catch (IOException e) {
             return "Failed to crawl the website: " + e.getMessage();

--- a/src/main/java/com/kobot/backend/controller/CrawlingController.java
+++ b/src/main/java/com/kobot/backend/controller/CrawlingController.java
@@ -1,0 +1,29 @@
+package com.kobot.backend.controller;
+
+import com.kobot.backend.service.CrawlingService;
+import java.net.URISyntaxException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+public class CrawlingController {
+
+    @Autowired
+    private CrawlingService crawlingService;
+
+    @GetMapping("/crawl")
+    public String crawl(@RequestParam String url) {
+        try {
+            crawlingService.crawl(url);
+            return "Crawling completed!";
+        } catch (IOException e) {
+            return "Failed to crawl the website: " + e.getMessage();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/kobot/backend/service/CrawlingService.java
+++ b/src/main/java/com/kobot/backend/service/CrawlingService.java
@@ -1,5 +1,10 @@
 package com.kobot.backend.service;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -18,13 +23,19 @@ public class CrawlingService {
 
     private Set<String> visitedLinks = new HashSet<>();
     private String domain;
+    private List<String> disallowedPaths = new ArrayList<>();
 
     public void crawl(String url) throws IOException, URISyntaxException {
         URI startUri = new URI(url);
         domain = startUri.getHost();
+        loadRobotsTxt(startUri);
 
         if (!visitedLinks.contains(url)) {
             visitedLinks.add(url);
+
+            // Disallow된 경로인지 확인
+            if (isDisallowed(url))
+                return;
             
             // 크롤링 할 url의 contentType 무시하는 설정
             Connection connection = Jsoup.connect(url).ignoreContentType(true);
@@ -49,4 +60,35 @@ public class CrawlingService {
             }
         }
     }
+
+    /* robots.txt 파일 로드 및 Disallow 경로 파싱 */
+    private void loadRobotsTxt(URI startUri) throws IOException {
+        String robotsUrl = startUri.getScheme() + "://" + startUri.getHost() + "/robots.txt";
+        String line;
+
+        try(BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new URI(robotsUrl).toURL().openStream()))) {
+            while ((line = bufferedReader.readLine()) != null) {
+                line = line.trim();
+                if (line.startsWith("Disallow:")) {
+                    String disallowPath = line.split(":", 2)[1].trim();
+                    disallowedPaths.add(disallowPath);
+                }
+            }
+        } catch (IOException | URISyntaxException e) {
+            System.out.println("Failed to load robots.txt, assuming no restrictions.");
+        }
+    }
+
+    /* 주어진 URL이 Disallow 목록에 있는지 확인 */
+    private boolean isDisallowed(String url) throws URISyntaxException {
+        URI uri = new URI(url);
+        String path = uri.getPath();
+
+        for (String disallowedPath : disallowedPaths) {
+            if (path.startsWith(disallowedPath))
+                return true;
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/com/kobot/backend/service/CrawlingService.java
+++ b/src/main/java/com/kobot/backend/service/CrawlingService.java
@@ -2,16 +2,11 @@ package com.kobot.backend.service;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 import org.jsoup.Connection;
-import org.jsoup.Connection.Response;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -61,6 +56,7 @@ public class CrawlingService {
             Connection connection = Jsoup.connect(url).ignoreContentType(true);
             Document document = connection.get();
 
+
             // 텍스트 데이터 추출
             String text = document.body().text();
             System.out.println("URL : " + url + " : " + text);
@@ -89,7 +85,7 @@ public class CrawlingService {
         }
     }
 
-    /* robots.txt 파일 로드 및 Disallow 경로 파싱 */
+    // robots.txt 파일 로드 및 Disallow 경로 파싱
     private void loadRobotsTxt(URI startUri) throws IOException {
         String robotsUrl = startUri.getScheme() + "://" + startUri.getHost() + "/robots.txt";
         String line;
@@ -107,7 +103,7 @@ public class CrawlingService {
         }
     }
 
-    /* 주어진 URL이 Disallow 목록에 있는지 확인 */
+    // 주어진 URL이 Disallow 목록에 있는지 확인
     private boolean isDisallowed(String url) throws URISyntaxException {
         URI uri = new URI(url);
         String path = uri.getPath();
@@ -119,6 +115,7 @@ public class CrawlingService {
         return false;
     }
 
+    // url에 있는 공백, 한글 인코딩
     private String encodeUrl(String url) throws IOException {
         try {
             // 전체 URL을 안전하게 인코딩
@@ -129,7 +126,7 @@ public class CrawlingService {
                 urlObj.getHost(),
                 urlObj.getPort(),
                 urlObj.getPath(),
-                urlObj.getQuery(),  // 쿼리 부분만 따로 인코딩하지 않음
+                urlObj.getQuery(),
                 urlObj.getRef()
             );
             return uri.toASCIIString();  // 인코딩된 URL 반환

--- a/src/main/java/com/kobot/backend/service/CrawlingService.java
+++ b/src/main/java/com/kobot/backend/service/CrawlingService.java
@@ -1,5 +1,6 @@
 package com.kobot.backend.service;
 
+import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -24,8 +25,11 @@ public class CrawlingService {
 
         if (!visitedLinks.contains(url)) {
             visitedLinks.add(url);
+            
+            // 크롤링 할 url의 contentType 무시하는 설정
+            Connection connection = Jsoup.connect(url).ignoreContentType(true);
 
-            Document document = Jsoup.connect(url).get();
+            Document document = connection.get();
 
             // 텍스트 데이터 추출
             String text = document.body().text();

--- a/src/main/java/com/kobot/backend/service/CrawlingService.java
+++ b/src/main/java/com/kobot/backend/service/CrawlingService.java
@@ -1,0 +1,48 @@
+package com.kobot.backend.service;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class CrawlingService {
+
+    private Set<String> visitedLinks = new HashSet<>();
+    private String domain;
+
+    public void crawl(String url) throws IOException, URISyntaxException {
+        URI startUri = new URI(url);
+        domain = startUri.getHost();
+
+        if (!visitedLinks.contains(url)) {
+            visitedLinks.add(url);
+
+            Document document = Jsoup.connect(url).get();
+
+            // 텍스트 데이터 추출
+            String text = document.body().text();
+            System.out.println("URL : " + url + " : " + text);
+
+            // 연결된 하이퍼링크 추출 후 재귀적으로 크롤링
+            Elements links = document.select("a[href]");
+
+            for (Element link : links) {
+                String absHref = link.attr("abs:href");
+
+                // 동일한 도메인에 속하는 URL만 크롤링
+                URI linkUri = new URI(absHref);
+                if (linkUri.getHost().equals(domain)) {
+                    crawl(absHref);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/kobot/backend/service/CrawlingService.java
+++ b/src/main/java/com/kobot/backend/service/CrawlingService.java
@@ -40,7 +40,8 @@ public class CrawlingService {
         crawlPage(encodedUrl, domain, 0);
     }
 
-    public void crawlPage(String url, String domain, int depth) throws IOException, URISyntaxException {
+    public void crawlPage(String url, String domain, int depth) throws IOException
+        , URISyntaxException {
         if (depth > MAX_DEPTH) {
             return;
         }
@@ -90,7 +91,8 @@ public class CrawlingService {
         String robotsUrl = startUri.getScheme() + "://" + startUri.getHost() + "/robots.txt";
         String line;
 
-        try(BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new URI(robotsUrl).toURL().openStream()))) {
+        try(BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(
+            new URI(robotsUrl).toURL().openStream()))) {
             while ((line = bufferedReader.readLine()) != null) {
                 line = line.trim();
                 if (line.startsWith("Disallow:")) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용
> 사용자가 input한 url과 연결된 하위 url들의 내용을 text 형태로 crawling 진행
- url을 host와 path로 나누어 host와 일치하는 주소들만 크롤링 
  - crawling하는 웹페이지에 외부 사이트들이 연결된 경우를 방지하기 위함
- crawling을 하며, 연결된 웹페이지 url들의 방문 깊이 제한
  - 성능과 정확성을 고려한 방문 깊이 설정 진행
  - 깊이 제한이 없다면 너무 많은 시간 소요
- host url에서 robots.txt를 확인하여 disallow되는 url들 미방문
- url 인코딩
  - url의 쿼리 부분에 공백이 발생하여 crawling 기능 수행 시 발생하는 에러 방지