### PR TITLE
Feature/16 Cache Template 생성(질의 캐시 공통화)

### DIFF
--- a/src/main/java/com/kobot/backend/CacheDto.java
+++ b/src/main/java/com/kobot/backend/CacheDto.java
@@ -15,4 +15,5 @@ public class CacheDto {
     private String query;
     private String answer;
     private float distance;
+    private long timestamp;
 }

--- a/src/main/java/com/kobot/backend/config/CacheConfig.java
+++ b/src/main/java/com/kobot/backend/config/CacheConfig.java
@@ -1,0 +1,29 @@
+package com.kobot.backend.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.kobot.backend.query.cache.QueryCache;
+import com.kobot.backend.query.cache.QueryCacheFactory;
+import com.kobot.backend.query.cache.QueryCacheFactory.DistanceMetric;
+import com.kobot.backend.query.cache.QueryCacheFactory.NeighborMetric;
+import com.kobot.backend.query.cache.elasticsearch.ElasticsearchQueryCacheFactory;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CacheConfig {
+
+    @Value("${com.kobot.query.cache.threshold}")
+    private float threshold;
+
+    @Bean
+    public QueryCache getQueryCache(ElasticsearchClient esClient, EmbeddingModel embeddingModel) {
+        QueryCacheFactory elasticsearchQueryCacheFactory = new ElasticsearchQueryCacheFactory(
+            esClient);
+        
+        return elasticsearchQueryCacheFactory.create(embeddingModel, DistanceMetric.COSINE,
+            NeighborMetric.KNN,
+            threshold);
+    }
+}

--- a/src/main/java/com/kobot/backend/config/CacheConfig.java
+++ b/src/main/java/com/kobot/backend/config/CacheConfig.java
@@ -21,9 +21,11 @@ public class CacheConfig {
     public QueryCache getQueryCache(ElasticsearchClient esClient, EmbeddingModel embeddingModel) {
         QueryCacheFactory elasticsearchQueryCacheFactory = new ElasticsearchQueryCacheFactory(
             esClient);
-        
+
         return elasticsearchQueryCacheFactory.create(embeddingModel, DistanceMetric.COSINE,
             NeighborMetric.KNN,
             threshold);
     }
+
+    // TODO scheduler 추가 - Cache 주기적으로 referesh
 }

--- a/src/main/java/com/kobot/backend/config/CacheConfig.java
+++ b/src/main/java/com/kobot/backend/config/CacheConfig.java
@@ -1,10 +1,10 @@
 package com.kobot.backend.config;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.kobot.backend.query.cache.AbstractQueryCacheFactory;
+import com.kobot.backend.query.cache.AbstractQueryCacheFactory.DistanceMetric;
+import com.kobot.backend.query.cache.AbstractQueryCacheFactory.NeighborMetric;
 import com.kobot.backend.query.cache.QueryCache;
-import com.kobot.backend.query.cache.QueryCacheFactory;
-import com.kobot.backend.query.cache.QueryCacheFactory.DistanceMetric;
-import com.kobot.backend.query.cache.QueryCacheFactory.NeighborMetric;
 import com.kobot.backend.query.cache.elasticsearch.ElasticsearchQueryCacheFactory;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,7 +19,7 @@ public class CacheConfig {
 
     @Bean
     public QueryCache getQueryCache(ElasticsearchClient esClient, EmbeddingModel embeddingModel) {
-        QueryCacheFactory elasticsearchQueryCacheFactory = new ElasticsearchQueryCacheFactory(
+        AbstractQueryCacheFactory elasticsearchQueryCacheFactory = new ElasticsearchQueryCacheFactory(
             esClient);
 
         return elasticsearchQueryCacheFactory.create(embeddingModel, DistanceMetric.COSINE,

--- a/src/main/java/com/kobot/backend/controller/PromptController.java
+++ b/src/main/java/com/kobot/backend/controller/PromptController.java
@@ -3,7 +3,6 @@ package com.kobot.backend.controller;
 import com.kobot.backend.service.PromptService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,12 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PromptController {
 
-  private final PromptService promptService;
+    private final PromptService promptService;
 
-  @PostMapping("/chat")
-  public String getQueryResult(@RequestBody String query) {
-    log.info(query);
-    ChatResponse chatResponse = promptService.getChatResponse(query);
-    return chatResponse.getResult().getOutput().getContent();
-  }
+    @PostMapping("/chat")
+    public String getQueryResult(@RequestBody String query) {
+        log.info(query);
+        return promptService.getChatResponse(query);
+    }
 }

--- a/src/main/java/com/kobot/backend/query/cache/AbstractQueryCacheFactory.java
+++ b/src/main/java/com/kobot/backend/query/cache/AbstractQueryCacheFactory.java
@@ -2,7 +2,7 @@ package com.kobot.backend.query.cache;
 
 import org.springframework.ai.embedding.EmbeddingModel;
 
-public abstract class QueryCacheFactory {
+public abstract class AbstractQueryCacheFactory {
 
     // TODO Metric은 객체 하나로 묶어서 받기
     public abstract QueryCache create(

--- a/src/main/java/com/kobot/backend/query/cache/QueryCache.java
+++ b/src/main/java/com/kobot/backend/query/cache/QueryCache.java
@@ -1,0 +1,32 @@
+package com.kobot.backend.query.cache;
+
+import com.kobot.backend.CacheDto;
+
+public interface QueryCache {
+
+    /**
+     * 질의와 답변을 캐시합니다.
+     *
+     * @param query  질의
+     * @param answer 답변
+     * @return 캐시된 객체. 캐시 실패 시, null
+     */
+    CacheDto cache(String query, String answer);
+
+    /**
+     * 질의와 유사한 질답을 캐시에서 꺼냅니다.
+     *
+     * @param query 질의
+     * @return 질답. cache miss 시, null
+     */
+    CacheDto getCached(String query);
+
+    /**
+     * 일정 시간이 된 캐시는 삭제합니다.
+     *
+     * @param from 삭제할 캐시 생성 시각의 최솟값
+     * @param to   삭제할 캐시 최대 생성 시각 최댓값
+     */
+    void clear(long from, long to);
+
+}

--- a/src/main/java/com/kobot/backend/query/cache/QueryCacheFactory.java
+++ b/src/main/java/com/kobot/backend/query/cache/QueryCacheFactory.java
@@ -4,16 +4,19 @@ import org.springframework.ai.embedding.EmbeddingModel;
 
 public abstract class QueryCacheFactory {
 
+    // TODO Metric은 객체 하나로 묶어서 받기
     public abstract QueryCache create(
         EmbeddingModel embeddingModel,
         DistanceMetric distanceMetric,
         NeighborMetric neighborMetric,
         float threshold);
 
+    // TODO 별도 클래스로 분리
     public enum DistanceMetric {
         DOT_PRODUCT, COSINE
     }
 
+    // TODO 별도 클래스로 분리
     public enum NeighborMetric {
         KNN, ANN
     }

--- a/src/main/java/com/kobot/backend/query/cache/QueryCacheFactory.java
+++ b/src/main/java/com/kobot/backend/query/cache/QueryCacheFactory.java
@@ -1,0 +1,20 @@
+package com.kobot.backend.query.cache;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+
+public abstract class QueryCacheFactory {
+
+    public abstract QueryCache create(
+        EmbeddingModel embeddingModel,
+        DistanceMetric distanceMetric,
+        NeighborMetric neighborMetric,
+        float threshold);
+
+    public enum DistanceMetric {
+        DOT_PRODUCT, COSINE
+    }
+
+    public enum NeighborMetric {
+        KNN, ANN
+    }
+}

--- a/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
+++ b/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
@@ -97,12 +97,12 @@ public class ElasticsearchCosineKnnQueryCache implements QueryCache {
                         .numCandidates((long) (1.5 * topK))
                     ),
                 Document.class);
-        } catch (IOException e) {
-            log.error("", e);
+        } catch (Exception e) {
+            log.error("Geting answer from cache is failed.", e);
             return null;
         }
 
-        log.debug("Score: {}", res.maxScore());
+        log.debug("Search result: {}", res);
 
         // TODO 아래 공통화
         List<CacheDto> cacheDtos = res.hits().hits().stream().map(r -> {

--- a/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
+++ b/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
@@ -33,8 +33,8 @@ public class ElasticsearchCosineKnnQueryCache implements QueryCache {
 
     private final float threshold = 0.8f;
 
-    @Value("com.kobot.query.cache.elasticsearch.index-name")
-    private String indexName = "kobot-user-query-index"; // FIXME pojo로
+    @Value("${com.kobot.query.cache.elasticsearch.index-name:kobot-user-query-index}")
+    private String indexName;
 
     private final long topK = 1L;
 

--- a/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
+++ b/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
@@ -1,44 +1,62 @@
-package com.kobot.backend.service;
+package com.kobot.backend.query.cache.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.IndexRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.json.JsonData;
 import com.kobot.backend.CacheDto;
+import com.kobot.backend.query.cache.QueryCache;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.model.EmbeddingUtils;
-import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class EsCacheService {
+
+public class ElasticsearchCosineKnnQueryCache implements QueryCache {
+
 
     private final EmbeddingModel embeddingModel;
     private final ElasticsearchClient client;
-    private final String indexName = "kobot-user-query-index";
+
+    private final Logger log = LoggerFactory.getLogger(ElasticsearchCosineKnnQueryCache.class);
+
     private final float threshold = 0.8f;
+
+    @Value("com.kobot.query.cache.elasticsearch.index-name")
+    private String indexName = "kobot-user-query-index"; // FIXME pojo로
+
     private final long topK = 1L;
 
-    /**
-     * 질의와 답변을 캐시합니다.
-     *
-     * @param query  질의
-     * @param answer 답변
-     * @return 캐시된 객체. 캐시 실패 시, null
-     */
+    public ElasticsearchCosineKnnQueryCache(EmbeddingModel embeddingModel,
+        ElasticsearchClient client) {
+        this.embeddingModel = embeddingModel;
+        this.client = client;
+    }
+
+    public ElasticsearchCosineKnnQueryCache(EmbeddingModel embeddingModel,
+        ElasticsearchClient client,
+        String indexName) {
+        this.embeddingModel = embeddingModel;
+        this.client = client;
+        this.indexName = indexName;
+    }
+
+    @Override
     public CacheDto cache(String query, String answer) {
         // metadata set
         Map<String, Object> metadata = new HashMap<>();
-        metadata.put("answer", answer);
+        metadata.put("answer", answer); // 필드 이름은 상수로 빼기
         metadata.put("timestamp", System.currentTimeMillis());
 
         // document set
@@ -64,12 +82,7 @@ public class EsCacheService {
         return convertToCachedDto(document);
     }
 
-    /**
-     * 질의와 유사한 질답을 캐시에서 꺼냅니다.
-     *
-     * @param query 질의
-     * @return 질답. cache miss 시, null
-     */
+    @Override
     public CacheDto getCached(String query) {
         float[] vectors = embeddingModel.embed(query);
 
@@ -91,6 +104,7 @@ public class EsCacheService {
 
         log.debug("Score: {}", res.maxScore());
 
+        // TODO 아래 공통화
         List<CacheDto> cacheDtos = res.hits().hits().stream().map(r -> {
             Document source = r.source();
             if (source == null) {
@@ -108,6 +122,27 @@ public class EsCacheService {
         return cacheDtos.getFirst();
     }
 
+    @Override
+    public void clear(long from, long to) {
+
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest.Builder()
+            .index(indexName)
+            .query(
+                RangeQuery.of(
+                        rq -> rq.gte(JsonData.of(from)).lte(JsonData.of(to))
+                            .field("metadata.timestamp"))
+                    ._toQuery())
+            .build();
+
+        try {
+            DeleteByQueryResponse response = client.deleteByQuery(deleteByQueryRequest);
+            log.info("Cached data which created between {} and {} is deleted.", from, to);
+            log.debug("Deleted data: {}", response);
+        } catch (IOException e) {
+            log.error("", e);
+        }
+    }
+
     private CacheDto convertToCachedDto(Document doc) {
         Map<String, Object> metadata = doc.getMetadata();
         Object distance = metadata.get("distance");
@@ -117,7 +152,6 @@ public class EsCacheService {
             .query((String) metadata.get("query"))
             .answer((String) metadata.get("answer"))
             .distance(distance == null ? -1f : (float) distance)
-            .timestamp((long) metadata.get("timestamp"))
             .build();
     }
 }

--- a/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
+++ b/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchCosineKnnQueryCache.java
@@ -143,6 +143,7 @@ public class ElasticsearchCosineKnnQueryCache implements QueryCache {
         }
     }
 
+    // TODO DTO쪽에 static 메소드로 선언하기
     private CacheDto convertToCachedDto(Document doc) {
         Map<String, Object> metadata = doc.getMetadata();
         Object distance = metadata.get("distance");

--- a/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchQueryCacheFactory.java
+++ b/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchQueryCacheFactory.java
@@ -1,11 +1,11 @@
 package com.kobot.backend.query.cache.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.kobot.backend.query.cache.AbstractQueryCacheFactory;
 import com.kobot.backend.query.cache.QueryCache;
-import com.kobot.backend.query.cache.QueryCacheFactory;
 import org.springframework.ai.embedding.EmbeddingModel;
 
-public class ElasticsearchQueryCacheFactory extends QueryCacheFactory {
+public class ElasticsearchQueryCacheFactory extends AbstractQueryCacheFactory {
 
     private final ElasticsearchClient esClient;
 

--- a/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchQueryCacheFactory.java
+++ b/src/main/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchQueryCacheFactory.java
@@ -1,0 +1,44 @@
+package com.kobot.backend.query.cache.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.kobot.backend.query.cache.QueryCache;
+import com.kobot.backend.query.cache.QueryCacheFactory;
+import org.springframework.ai.embedding.EmbeddingModel;
+
+public class ElasticsearchQueryCacheFactory extends QueryCacheFactory {
+
+    private final ElasticsearchClient esClient;
+
+    // support metrics
+    private final MetricPair cosineKnn = new MetricPair(DistanceMetric.COSINE, NeighborMetric.KNN);
+
+
+    public ElasticsearchQueryCacheFactory(ElasticsearchClient esClient) {
+        if (esClient == null) {
+            throw new IllegalArgumentException("'esClient' must not be null.");
+        }
+        this.esClient = esClient;
+    }
+
+    @Override
+    public QueryCache create(EmbeddingModel embeddingModel, DistanceMetric distanceMetric,
+        NeighborMetric neighborMetric, float threshold) {
+        if (embeddingModel == null) {
+            throw new IllegalArgumentException("'embeddingMode' must not be null.");
+        }
+
+        MetricPair metricPair = new MetricPair(distanceMetric, neighborMetric);
+
+        if (cosineKnn.equals(metricPair)) {
+            return new ElasticsearchCosineKnnQueryCache(embeddingModel, esClient);
+        }
+
+        throw new IllegalArgumentException(
+            "distanceMetric " + distanceMetric + " and neighborMetric " + neighborMetric
+                + "are not supported.");
+    }
+
+    record MetricPair(DistanceMetric distanceMetric, NeighborMetric neighborMetric) {
+
+    }
+}

--- a/src/main/java/com/kobot/backend/service/PromptService.java
+++ b/src/main/java/com/kobot/backend/service/PromptService.java
@@ -1,10 +1,11 @@
 package com.kobot.backend.service;
 
+import com.kobot.backend.CacheDto;
+import com.kobot.backend.query.cache.QueryCache;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.QuestionAnswerAdvisor;
 import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
@@ -14,20 +15,29 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PromptService {
 
-  private final ChatModel chatModel;
-  private final VectorStore vectorStore;
+    private final ChatModel chatModel;
+    private final VectorStore vectorStore;
+    private final QueryCache queryCache;
 
-  public ChatResponse getChatResponse(String query) {
+    public String getChatResponse(String query) {
+        CacheDto cached = queryCache.getCached(query);
+        if (cached != null) {
+            return cached.getAnswer();
+        }
 
-    final OpenAiChatOptions options = OpenAiChatOptions.builder()
-        .withModel("gpt-4")
-        .withTemperature(0.2F).build();
+        final OpenAiChatOptions options = OpenAiChatOptions.builder()
+            .withModel("gpt-4")
+            .withTemperature(0.2F).build();
 
-    return ChatClient.builder(chatModel)
-        .build().prompt()
-        .advisors(new QuestionAnswerAdvisor(vectorStore, SearchRequest.defaults()))
-        .user(query).options(options)
-        .call()
-        .chatResponse();
-  }
+        String answer = ChatClient.builder(chatModel)
+            .build().prompt()
+            .advisors(new QuestionAnswerAdvisor(vectorStore, SearchRequest.defaults()))
+            .user(query).options(options)
+            .call()
+            .chatResponse().getResult().getOutput().getContent();
+
+        queryCache.cache(query, answer);
+
+        return answer;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,9 @@ spring:
 
   profiles:
     include: secret
+
+com:
+  kobot:
+    query:
+      cache:
+        threshold: 0.8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,6 @@ com:
     query:
       cache:
         threshold: 0.8
+logging:
+  level:
+    com.kobot.backend: debug

--- a/src/test/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchQueryCacheTest.java
+++ b/src/test/java/com/kobot/backend/query/cache/elasticsearch/ElasticsearchQueryCacheTest.java
@@ -1,0 +1,51 @@
+package com.kobot.backend.query.cache.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.kobot.backend.CacheDto;
+import com.kobot.backend.KobotBackendApplication;
+import com.kobot.backend.query.cache.QueryCache;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = KobotBackendApplication.class)
+@Slf4j
+class ElasticsearchQueryCacheTest {
+
+    @Autowired
+    EmbeddingModel embeddingModel;
+
+    @Autowired
+    ElasticsearchClient esClient;
+
+    QueryCache queryCache;
+
+    @BeforeEach
+    void before() {
+        queryCache = new ElasticsearchCosineKnnQueryCache(embeddingModel, esClient);
+    }
+
+    @Test
+    void cache() {
+        CacheDto result = queryCache.cache("한국의 수도가 어디야?", "서울");
+        Assertions.assertThat(result).isNotNull();
+    }
+
+    @Test
+    void getCached() {
+        CacheDto cached = queryCache.getCached("한국의 수도는?");
+        Assertions.assertThat(cached).isNotNull();
+        log.info("{}", cached);
+    }
+
+    @Test
+    void clear() {
+        queryCache.clear(0, System.currentTimeMillis());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#16 

## 📝작업 내용
> 질의 캐시 공통화

- 캐시 공통 로직을 interface화: cache/getCache/clear
  - 캐시 사용자는 해당 interface를 통해 캐시 이용

![image](https://github.com/user-attachments/assets/0a34b75e-4ef1-4dc8-869e-fb15223e2e38)

- `QueryCache`: 캐시 기본 로직에 대한 interface
  - 각 Vector DB, embedding 거리 유사도(거리) 계산 방식 등을 subclass에서 구현
- `AbstractQueryCacheFactory`: QueryCache 생성에 대한 추상 Factory
  - 각 VectorDB에 대해 구체 클래스 작성. 구체 클래스에서는 해당 DB에서 지원하는 거리 계산 방식 등을 확인하여 QueryCache에 대한 subclass 객체를 생성